### PR TITLE
bump to 12.1.3.x, drop CTK12 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,12 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_cuda_compiler_version12.9:
-        CONFIG: linux_64_cuda_compiler_version12.9
+      linux_64_cuda_compiler_version13.0:
+        CONFIG: linux_64_cuda_compiler_version13.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_cuda_compiler_version12.9:
-        CONFIG: linux_aarch64_cuda_compiler_version12.9
+      linux_aarch64_cuda_compiler_version13.0:
+        CONFIG: linux_aarch64_cuda_compiler_version13.0
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version13.0.yaml
@@ -1,5 +1,3 @@
-arm_variant_type:
-- sbsa
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -17,11 +13,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
-- linux-aarch64
+- linux-64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/linux_aarch64_cuda_compiler_version13.0.yaml
+++ b/.ci_support/linux_aarch64_cuda_compiler_version13.0.yaml
@@ -1,3 +1,5 @@
+arm_variant_type:
+- sbsa
 c_compiler:
 - gcc
 c_compiler_version:
@@ -6,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,11 +15,11 @@ channel_targets:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- '12.9'
+- '13.0'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 target_platform:
-- linux-64
+- linux-aarch64
 xz:
 - '5'
 zip_keys:

--- a/.ci_support/migrations/cuda130.yaml
+++ b/.ci_support/migrations/cuda130.yaml
@@ -1,0 +1,61 @@
+migrator_ts: 1755016036
+__migrator:
+  operation: key_add
+  migration_number:
+    1
+  build_number:
+    0
+  paused: true
+  use_local: true
+  override_cbc_keys:
+    - cuda_compiler_stub
+  check_solvable: false
+  primary_key: cuda_compiler_version
+  ordering:
+    cuda_compiler_version:
+      - 12.4
+      - 12.6
+      - 12.8
+      - None
+      - 12.9
+      - 13.0
+      # to allow manual opt-in for CUDA 11.8, see
+      # https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/7472
+      # must be last due to how cuda_compiler ordering in that migrator works
+      - 11.8
+  wait_for_migrators:
+    - cuda129
+  commit_message: |
+    Upgrade to CUDA 13.0
+
+    CUDA 13.0 removed support for architectures before `sm_75`, and renamed `sm_101` to
+    `sm_110`. To build for these, maintainers will need to modify their existing list of
+    specified architectures (e.g. `CMAKE_CUDA_ARCHITECTURES`, `TORCH_CUDA_ARCH_LIST`, etc.)
+    for their package.
+
+    Since CUDA 12.8, the conda-forge nvcc package now sets `CUDAARCHS` and
+    `TORCH_CUDA_ARCH_LIST` in its activation script to a string containing all
+    of the supported real architectures plus the virtual architecture of the
+    latest. Recipes for packages who use these variables to control their build
+    but do not want to build for all supported architectures will need to override
+    these variables in their build script.
+
+    ref: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#new-features
+
+cuda_compiler_version:         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 13.0                       # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cudnn:                         # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 9                          # [((linux and (x86_64 or aarch64)) or win64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+c_stdlib_version:              # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 2.17                       # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+c_compiler_version:            # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+cxx_compiler_version:          # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+
+fortran_compiler_version:      # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
+  - 14                         # [(linux and (x86_64 or aarch64)) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ About libcufftmp-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/libcufftmp-feedstock/blob/main/LICENSE.txt)
 
-Home: https://docs.nvidia.com/hpc-sdk/cufftmp
+Home: https://docs.nvidia.com/cuda/cufftmp/
 
-Package license: [LicenseRef-NVIDIA-End-User-License-Agreement](https://docs.nvidia.com/cuda/cublasdx/license.html)
+Package license: [LicenseRef-NVIDIA-End-User-License-Agreement](https://docs.nvidia.com/cuda/cufftmp/license.html)
 
 Summary: The NVIDIA cuFFTMp (cuFFT Multi-process) library
 
-Documentation: https://docs.nvidia.com/hpc-sdk/cufftmp
+Documentation: https://docs.nvidia.com/cuda/cufftmp/
 
 The multi-node FFT functionality, available through the cuFFTMp API, enables scientists and engineers to solve distributed 2D and 3D FFTs in exascale problems. The library handles all the communications between machines, allowing users to focus on other aspects of their problems.
 
@@ -31,17 +31,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_cuda_compiler_version12.9</td>
+              <td>linux_64_cuda_compiler_version13.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25304&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libcufftmp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version12.9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libcufftmp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_cuda_compiler_version13.0" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_cuda_compiler_version12.9</td>
+              <td>linux_aarch64_cuda_compiler_version13.0</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25304&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libcufftmp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version12.9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/libcufftmp-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_cuda_compiler_version13.0" alt="variant">
                 </a>
               </td>
             </tr>
@@ -129,12 +129,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -161,7 +161,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/libcufftmp-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-set -e
-
-check-glibc lib/libcufftMp.so.*
+set -ex
 
 mkdir -p $PREFIX/lib/
 
 cp -rv include $PREFIX/
-cp -rv lib $PREFIX/
+cp -rv lib/$CUDA_MAJOR_VERSION/* $PREFIX/lib
+
+check-glibc $PREFIX/lib/libcufftMp.so.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set extension = "tar.xz" %}  # [unix]
 
-{% set cuda_compiler_version = cuda_compiler_version|default("None") %}
+{% set cuda_compiler_version = cuda_compiler_version | default("None") %}
 {% set cuda_major_version  = cuda_compiler_version.split('.')[0] %}
 
 {% set sha256 = "3f4e447d0fb3571ddd751cd7215f182a1c14dbc4ff23cdfc988ef491a6cc984a" %}  # [linux64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,29 @@
-{% set version = "11.4.0.6" %}
+{% set version = "12.1.3.2" %}
+{% set abiversion = version.split('.')[0] %}
+{% set libversion = version.split('.')[:3] | join('.') %}
 {% set platform = "linux-sbsa" %}  # [aarch64]
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set extension = "tar.xz" %}  # [unix]
 
 {% set cuda_compiler_version = cuda_compiler_version|default("None") %}
+{% set cuda_major_version  = cuda_compiler_version.split('.')[0] %}
 
-{% set sha256 = "6a0597e10e698ab46ea9a607efe06f681ba6e2bf0d8eddd8a72a09c18a8f7253" %}  # [linux64]
-{% set sha256 = "c0f944fd6ef2e13ef5adfd48ef2e02660f5f573a69c515580096a9eaae13be16" %}  # [aarch64]
+{% set sha256 = "3f4e447d0fb3571ddd751cd7215f182a1c14dbc4ff23cdfc988ef491a6cc984a" %}  # [linux64]
+{% set sha256 = "17482614488d9ed190d576ba041762df8252b9a67768cbc118042c6603a78c19" %}  # [aarch64]
 
 package:
   name: libcufftmp-split
   version: {{ version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cufftmp/redist/libcufftmp/{{ platform }}/libcufftmp-{{ platform }}-{{ version }}_cuda12-archive.{{ extension }}  # [(cuda_compiler_version or "").startswith("12")]
+  url: https://developer.download.nvidia.com/compute/cufftmp/redist/libcufftmp/{{ platform }}/libcufftmp-{{ platform }}-{{ version }}_cuda13-archive.{{ extension }}  # [(cuda_compiler_version or "").startswith("13")]
   sha256: {{ sha256 }}
 
 build:
-  number: 2
-  skip: true  # [(cuda_compiler_version in (None, "None", "11.8")) or (not (linux64 or aarch64))]
+  script_env:
+    - CUDA_MAJOR_VERSION={{ cuda_major_version }}
+  number: 0
+  skip: true  # [(cuda_compiler_version or "").startswith("12") or cuda_compiler_version == "None" or not (linux64 or aarch64)]
 
 requirements:
   build:
@@ -46,8 +51,8 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
-        - test -f $PREFIX/lib/libcufftMp.so.11
-        - test -f $PREFIX/lib/libcufftMp.so.11.4.0
+        - test -f $PREFIX/lib/libcufftMp.so.{{ abiversion }}
+        - test -f $PREFIX/lib/libcufftMp.so.{{ libversion }}
 
   - name: libcufftmp-dev
     build:
@@ -76,17 +81,17 @@ outputs:
         - test -f $PREFIX/include/cufftXt.h
 
 about:
-  home: https://docs.nvidia.com/hpc-sdk/cufftmp
+  home: https://docs.nvidia.com/cuda/cufftmp/
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_file: LICENSE
-  license_url: https://docs.nvidia.com/cuda/cublasdx/license.html
+  license_url: https://docs.nvidia.com/cuda/cufftmp/license.html
   summary: The NVIDIA cuFFTMp (cuFFT Multi-process) library
   description: >-
     The multi-node FFT functionality, available through the cuFFTMp API, enables
     scientists and engineers to solve distributed 2D and 3D FFTs in exascale
     problems. The library handles all the communications between machines,
     allowing users to focus on other aspects of their problems.
-  doc_url: https://docs.nvidia.com/hpc-sdk/cufftmp
+  doc_url: https://docs.nvidia.com/cuda/cufftmp/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 {% set extension = "tar.xz" %}  # [unix]
 
 {% set cuda_compiler_version = cuda_compiler_version | default("None") %}
-{% set cuda_major_version  = cuda_compiler_version.split('.')[0] %}
+{% set cuda_major_version = cuda_compiler_version.split('.')[0] %}
 
 {% set sha256 = "3f4e447d0fb3571ddd751cd7215f182a1c14dbc4ff23cdfc988ef491a6cc984a" %}  # [linux64]
 {% set sha256 = "17482614488d9ed190d576ba041762df8252b9a67768cbc118042c6603a78c19" %}  # [aarch64]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
For CTK12, users should use v11.4.0.6. For this version we have support for CTK13 only.
<!--
Please add any other relevant info below:
-->
Closes #4
